### PR TITLE
增加查询不到的响应情况

### DIFF
--- a/pages/booktravel/bookdetails/index.js
+++ b/pages/booktravel/bookdetails/index.js
@@ -38,6 +38,15 @@ Page({
         console.log(res.data);
         let data = res.data;
         let tags = '';
+
+        if(data.code == 6000) {
+          wx.redirectTo({
+            url: '../error/index',
+          });
+
+          return ;
+        }
+
         data.tags.forEach((v)=>{
           tags += v.name;
         });


### PR DESCRIPTION
当无法从书库查找到图书信息的情况下, 跳转到错误提示页面.